### PR TITLE
pytest-asyncio 0.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-asyncio" %}
-{% set version = "0.15.1" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f
+  sha256: 7496c5977ce88c34379df64a66459fe395cd05543f0a2f837016e7144391fcfb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,18 +28,10 @@ requirements:
 test:
   imports:
     - pytest_asyncio
-  source_files:
-    - src/tests
   requires:
     - pip
-    - coverage
-    - hypothesis >=5.7.1
   commands:
     - pip check
-    - cd src
-    # the skip is for docker network issues in CI, reduces coverage from 96
-    - coverage run -m pytest -vv -k 'not (unused_port_fixture or unused_port_factory_fixture)'
-    - coverage report --fail-under 91
 
 about:
   home: http://github.com/pytest-dev/pytest-asyncio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,15 @@ source:
 
 build:
   number: 0
-  skip: true  # [py2k]
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - pytest >=5.4.0
@@ -26,14 +28,27 @@ requirements:
 test:
   imports:
     - pytest_asyncio
+  source_files:
+    - src/tests
+  requires:
+    - pip
+    - coverage
+    - hypothesis >=5.7.1
+  commands:
+    - pip check
+    - cd src
+    # the skip is for docker network issues in CI, reduces coverage from 96
+    - coverage run -m pytest -vv -k 'not (unused_port_fixture or unused_port_factory_fixture)'
+    - coverage report --fail-under 91
 
 about:
   home: http://github.com/pytest-dev/pytest-asyncio
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   #license_file: LICENSE # License file is missing in package
   summary: Pytest support for asyncio
-
+  doc_url: https://github.com/pytest-dev/pytest-asyncio/blob/master/README.rst
   dev_url: https://github.com/pytest-dev/pytest-asyncio
 
 extra:


### PR DESCRIPTION
Update pytest-asyncio to 0.16.0

Version change: bump version number from 0.15.1 to 0.16.0
Bug Tracker: new open issues https://github.com/pytest-dev/pytest-asyncio/issues
Upstream license:  License file:  https://github.com/pytest-dev/pytest-asyncio/blob/master/LICENSE
Upstream setup.py:  https://github.com/pytest-dev/pytest-asyncio/blob/master/setup.py

The package pytest-asyncio is mentioned inside the packages:
jupyter_client | pytest-mock | tqdm |

Actions:
1. Skip py<36
2. Add missing packages
3. Add pip check
4. Add license_family and doc_url

Result:
- all-succeeded
