### PR TITLE
pytest-asyncio 0.18.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,39 +6,52 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fc8e4190f33fee7797cc7f1829f46a82c213f088af5d1bb5d4e454fe87e6cdc2
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: fc8e4190f33fee7797cc7f1829f46a82c213f088af5d1bb5d4e454fe87e6cdc2
+  - folder: src
+    url: https://github.com/pytest-dev/pytest-asyncio/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: bbeb4dc968bcef0c69d2467634e5bd86158df819f705a78358cc39f817260d4b
 
 build:
   number: 0
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  noarch: python
+  script: cd dist && {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - setuptools >=51.0
+    - setuptools_scm >=6.2
+    - toml
+    - wheel >=0.36
   run:
-    - python
+    - python >=3.7
     - pytest >=5.4.0
+    - typing_extensions >=3.7.2
 
 test:
+  source_files:
+    - src/tests
   imports:
     - pytest_asyncio
   requires:
     - pip
+    - coverage
+    - hypothesis >=5.7.1
   commands:
     - pip check
+    - cd src
+    # the skip is for docker network issues in CI, reduces coverage from 96
+    - coverage run -m pytest -vv -k 'not (unused_port_fixture or unused_port_factory_fixture or auto_mode_cmdline)'
+    - coverage report --fail-under 91
 
 about:
-  home: http://github.com/pytest-dev/pytest-asyncio
+  home: https://github.com/pytest-dev/pytest-asyncio
   license: Apache-2.0
   license_family: Apache
-  license_file: LICENSE
-  #license_file: LICENSE # License file is missing in package
+  license_file: dist/LICENSE
   summary: Pytest support for asyncio
   doc_url: https://github.com/pytest-dev/pytest-asyncio/blob/master/README.rst
   dev_url: https://github.com/pytest-dev/pytest-asyncio


### PR DESCRIPTION
Update pytest-asyncio to 0.18.2

Changelog: https://github.com/pytest-dev/pytest-asyncio/blob/master/CHANGELOG.rst
License: https://github.com/pytest-dev/pytest-asyncio/blob/v0.18.2/LICENSE
Requirements: 
- https://github.com/pytest-dev/pytest-asyncio/blob/v0.18.2/pyproject.toml
- https://github.com/pytest-dev/pytest-asyncio/blob/v0.18.2/setup.cfg

Actions:
1. Update source: add folders
2. Remove skip py<36
3. Make noarh: python
4. Update script
5. Update host and run dependencies
6. Use python >=3.7 in run
7. Add pytest and commands in test
8. Fix home url with HTTPS
9. Fix license file