### PR TITLE
Update pytest-asyncio to 0.21.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-asyncio" %}
-{% set version = "0.20.3" %}
+{% set version = "0.21.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   - folder: dist
-    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name.replace("-", "_") }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45
   - folder: src
     url: https://github.com/pytest-dev/pytest-asyncio/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 71167da362a2c1ab22a048463eb2954b7f15fba18d41eee6a3b9db03863a2580
+    sha256: 6ab1c5c0ad8d5aa01d80e51a57b7385fefab4f535bb3db2f6a2a27ad7f59a7c8
 
 build:
   number: 0
@@ -28,7 +28,7 @@ requirements:
     - wheel
   run:
     - python
-    - pytest >=6.1.0
+    - pytest >=7
     - typing_extensions >=3.7.2  # [py<38]
 
 test:
@@ -58,7 +58,7 @@ about:
   license_file: dist/LICENSE
   summary: Pytest support for asyncio
   description: |
-    pytest-asyncio is a pytest plugin. 
+    pytest-asyncio is a pytest plugin.
     It facilitates testing of code that uses the asyncio library.
   doc_url: https://github.com/pytest-dev/pytest-asyncio/blob/master/README.rst
   dev_url: https://github.com/pytest-dev/pytest-asyncio


### PR DESCRIPTION
pytest-asyncio 0.21.2 with py3.13 support

**Destination channel:** {defaults}

### Links

- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - `[ipython 8.30](https://github.com/AnacondaRecipes/ipython-feedstock/pull/46)` 

### Explanation of changes:

- ...
